### PR TITLE
refactor: changing the interface of the projects to sync with front-end standard

### DIFF
--- a/src/controllers/CreateProjectController.ts
+++ b/src/controllers/CreateProjectController.ts
@@ -1,15 +1,27 @@
 import { NextFunction, Request, Response } from 'express';
-import { IProject } from '../schemas/ProjectSchema';
+import { RequestProjectBody, ProjectModel } from '../schemas/ProjectSchema';
 import { CreateProjectService } from '../services';
 
 export class CreateProjectController {
     public async handle(req: Request, res: Response, next: NextFunction) {
         try {
             const { body } = req;
-            const project: IProject = body;
+            const project: RequestProjectBody = body;
             const service = new CreateProjectService();
-            const result = await service.execute(project);
-            res.status(200).send({ project: result });
+            const result = (await service.execute(project)) as ProjectModel;
+
+            const { id, name, description, stack, sourceCode, livePreview } = result;
+
+            const createdProject: ProjectModel = {
+                id,
+                name,
+                description,
+                stack,
+                sourceCode,
+                livePreview
+            };
+
+            res.status(200).send({ project: createdProject });
         } catch (error) {
             next(error);
         }

--- a/src/middlewares/CreateProjectHandler.ts
+++ b/src/middlewares/CreateProjectHandler.ts
@@ -1,12 +1,13 @@
 import { Request, Response, NextFunction } from 'express';
+import { RequestProjectBody } from '../schemas/ProjectSchema';
 import { ApiError } from '../errors';
 
 export class CreateProjectHandler {
     public async handle(req: Request, _res: Response, next: NextFunction) {
         try {
-            const { body } = req;
+            const { body }: { body: RequestProjectBody } = req;
 
-            const { name, description, github, logo, app } = body;
+            const { name, description, stack, sourceCode, livePreview } = body;
 
             // name field verifications
             if (!name) {
@@ -26,27 +27,37 @@ export class CreateProjectHandler {
                 throw ApiError.badRequest('Project description must be a string.');
             }
 
-            // github field verifications
-            if (!github) {
-                throw ApiError.badRequest('Project Github link is required.');
+            // stack field verifications
+            if (!stack) {
+                throw ApiError.badRequest('Project stack is required.');
             }
 
-            if (typeof github !== 'string') {
-                throw ApiError.badRequest('Project Github link must be a string.');
+            let stackItemNotString = false;
+
+            stack.forEach((item) => {
+                if (typeof item !== 'string') stackItemNotString = true;
+            });
+
+            if (Array.isArray(stack) && stackItemNotString) {
+                throw ApiError.badRequest('Project stack must be a string array.');
             }
 
-            // logo field verifications
-            if (!logo) {
-                throw ApiError.badRequest('Project logo is required.');
+            // sourceCode field verifications
+            if (!sourceCode) {
+                throw ApiError.badRequest('Project sourceCode is required.');
             }
 
-            if (typeof logo !== 'string') {
-                throw ApiError.badRequest('Project logo must be a string.');
+            if (typeof sourceCode !== 'string') {
+                throw ApiError.badRequest('Project sourceCode must be a string.');
             }
 
-            // app field verifications
-            if (app && typeof app !== 'string') {
-                throw ApiError.badRequest('Project app must be a string.');
+            // livePreview field verifications
+            if (!livePreview) {
+                throw ApiError.badRequest('Project livePreview is required.');
+            }
+
+            if (typeof livePreview !== 'string') {
+                throw ApiError.badRequest('Project livePreview must be a string.');
             }
 
             next();

--- a/src/schemas/ProjectSchema.ts
+++ b/src/schemas/ProjectSchema.ts
@@ -1,16 +1,24 @@
 import { Schema, model } from 'mongoose';
 import { v4 as uuidv4 } from 'uuid';
 
-export interface IProject {
-    id?: string;
+export interface RequestProjectBody {
     name: string;
     description: string;
-    app?: string;
-    github: string;
-    logo: string;
+    stack: string[];
+    sourceCode: string;
+    livePreview: string;
 }
 
-const ProjectSchema = new Schema<IProject>({
+export interface ProjectModel {
+    id: string;
+    name: string;
+    description: string;
+    stack: string[];
+    sourceCode: string;
+    livePreview: string;
+}
+
+const ProjectSchema = new Schema<ProjectModel>({
     id: {
         type: String,
         default: uuidv4,
@@ -26,18 +34,18 @@ const ProjectSchema = new Schema<IProject>({
         type: String,
         required: true
     },
-    app: {
-        type: String,
-        required: false
+    stack: {
+        type: [String],
+        required: true
     },
-    github: {
+    sourceCode: {
         type: String,
         required: true
     },
-    logo: {
+    livePreview: {
         type: String,
         required: true
     }
 });
 
-export const Project = model<IProject>('project', ProjectSchema);
+export const Project = model<ProjectModel>('project', ProjectSchema);

--- a/src/services/CreateProjectService.ts
+++ b/src/services/CreateProjectService.ts
@@ -1,8 +1,8 @@
-import { IProject, Project } from '../schemas/ProjectSchema';
+import { RequestProjectBody, Project } from '../schemas/ProjectSchema';
 import { MongooseError } from '../errors';
 
 export class CreateProjectService {
-    public async execute(project: IProject): Promise<IProject> {
+    public async execute(project: RequestProjectBody): Promise<RequestProjectBody> {
         const newProject = new Project(project);
 
         if (await Project.findOne({ name: project.name })) {

--- a/src/services/GetProjectsService.ts
+++ b/src/services/GetProjectsService.ts
@@ -1,7 +1,7 @@
-import { IProject, Project } from '../schemas/ProjectSchema';
+import { RequestProjectBody, Project } from '../schemas/ProjectSchema';
 
 export class GetProjectsService {
-    public async execute(): Promise<IProject[]> {
+    public async execute(): Promise<RequestProjectBody[]> {
         const data = await Project.find({}).select('-_id -__v');
         return data;
     }

--- a/src/swagger/index.ts
+++ b/src/swagger/index.ts
@@ -1,3 +1,7 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
 export const swaggerOptions = {
     openapi: '3.0.3',
     info: {
@@ -16,7 +20,7 @@ export const swaggerOptions = {
     },
     servers: [
         {
-            url: 'http://localhost:3000/v1',
+            url: `http://localhost:${process.env.PORT}/v1`,
             description: 'Development server'
         },
         {
@@ -40,7 +44,7 @@ export const swaggerOptions = {
                                         projects: {
                                             type: 'array',
                                             items: {
-                                                $ref: '#/components/schemas/ListProject'
+                                                $ref: '#/components/schemas/ResponseBodyProject'
                                             }
                                         }
                                     }
@@ -69,7 +73,7 @@ export const swaggerOptions = {
                     content: {
                         'application/json': {
                             schema: {
-                                $ref: '#/components/schemas/Project'
+                                $ref: '#/components/schemas/RequestBodyProject'
                             }
                         }
                     }
@@ -89,7 +93,7 @@ export const swaggerOptions = {
                                     properties: {
                                         project: {
                                             type: 'object',
-                                            $ref: '#/components/schemas/CreateProject'
+                                            $ref: '#/components/schemas/CreatedProject'
                                         }
                                     }
                                 }
@@ -209,7 +213,30 @@ export const swaggerOptions = {
     },
     components: {
         schemas: {
-            ListProject: {
+            RequestBodyProject: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string'
+                    },
+                    description: {
+                        type: 'string'
+                    },
+                    stack: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    },
+                    sourceCode: {
+                        type: 'string'
+                    },
+                    livePreview: {
+                        type: 'string'
+                    }
+                }
+            },
+            ResponseBodyProject: {
                 type: 'object',
                 properties: {
                     id: {
@@ -221,62 +248,45 @@ export const swaggerOptions = {
                     description: {
                         type: 'string'
                     },
-                    github: {
+                    stack: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    },
+                    sourceCode: {
                         type: 'string'
                     },
-                    logo: {
+                    livePreview: {
                         type: 'string'
-                    },
-                    app: {
-                        type: 'string',
-                        required: false
                     }
                 }
             },
-            Project: {
+            CreatedProject: {
                 type: 'object',
                 properties: {
+                    id: {
+                        type: 'string'
+                    },
                     name: {
                         type: 'string'
                     },
                     description: {
                         type: 'string'
                     },
-                    github: {
+                    stack: {
+                        type: 'array',
+                        items: {
+                            type: 'string'
+                        }
+                    },
+                    sourceCode: {
                         type: 'string'
                     },
-                    logo: {
+                    livePreview: {
                         type: 'string'
-                    },
-                    app: {
-                        type: 'string',
-                        required: false
-                    }
-                }
-            },
-            CreateProject: {
-                type: 'object',
-                properties: {
-                    name: {
-                        type: 'string'
-                    },
-                    description: {
-                        type: 'string'
-                    },
-                    github: {
-                        type: 'string'
-                    },
-                    logo: {
-                        type: 'string'
-                    },
-                    app: {
-                        type: 'string',
-                        required: false
                     },
                     _id: {
-                        type: 'string'
-                    },
-                    id: {
                         type: 'string'
                     },
                     __v: {

--- a/src/tests/controllers/CreateProjectController.int.test.ts
+++ b/src/tests/controllers/CreateProjectController.int.test.ts
@@ -5,8 +5,8 @@ import supertest from 'supertest';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { app } from '../../app';
-import { Project } from '../../schemas/ProjectSchema';
-import { projectWithApp, projectWithoutApp } from '../mocks/Projects';
+import { Project, ProjectModel } from '../../schemas/ProjectSchema';
+import { projectOne, projectTwo } from '../mocks/Projects';
 import { uuidv4Regex } from '../../utils';
 
 describe('CreateProjectController', () => {
@@ -24,55 +24,60 @@ describe('CreateProjectController', () => {
         await mongoServer.stop();
     });
 
-    it('should create a project without app', async () => {
+    it('should create a project', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
-            .send(projectWithoutApp)
+            .send(projectOne)
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
+
+        const project = response.body.project as ProjectModel;
 
         expect(response.status).toEqual(200);
         expect(response.body).toHaveProperty('project');
-        expect(response.body.project).toHaveProperty('id');
-        expect(response.body.project.id).toMatch(uuidv4Regex);
-        expect(response.body.project).toHaveProperty('name');
-        expect(response.body.project.name).toEqual(projectWithoutApp.name);
-        expect(response.body.project).toHaveProperty('description');
-        expect(response.body.project.description).toEqual(projectWithoutApp.description);
-        expect(response.body.project).toHaveProperty('github');
-        expect(response.body.project.github).toEqual(projectWithoutApp.github);
-        expect(response.body.project).toHaveProperty('logo');
-        expect(response.body.project.logo).toEqual(projectWithoutApp.logo);
-        expect(response.body.project).not.toHaveProperty('app');
+        expect(project).toHaveProperty('id');
+        expect(project.id).toMatch(uuidv4Regex);
+        expect(project).toHaveProperty('name');
+        expect(project.name).toEqual(projectOne.name);
+        expect(project).toHaveProperty('description');
+        expect(project.description).toEqual(projectOne.description);
+        expect(project).toHaveProperty('stack');
+        expect(project.stack).toEqual(projectOne.stack);
+        expect(project).toHaveProperty('sourceCode');
+        expect(project.sourceCode).toEqual(projectOne.sourceCode);
+        expect(project).toHaveProperty('livePreview');
+        expect(project.livePreview).toEqual(projectOne.livePreview);
     });
 
-    it('should create a project with app', async () => {
+    it('should create a second project', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
-            .send(projectWithApp)
+            .send(projectTwo)
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
+
+        const project = response.body.project as ProjectModel;
 
         expect(response.status).toEqual(200);
         expect(response.body).toHaveProperty('project');
-        expect(response.body.project).toHaveProperty('id');
-        expect(response.body.project.id).toMatch(uuidv4Regex);
-        expect(response.body.project).toHaveProperty('name');
-        expect(response.body.project.name).toEqual(projectWithApp.name);
-        expect(response.body.project).toHaveProperty('description');
-        expect(response.body.project.description).toEqual(projectWithApp.description);
-        expect(response.body.project).toHaveProperty('github');
-        expect(response.body.project.github).toEqual(projectWithApp.github);
-        expect(response.body.project).toHaveProperty('logo');
-        expect(response.body.project.logo).toEqual(projectWithApp.logo);
-        expect(response.body.project).toHaveProperty('app');
-        expect(response.body.project.app).toEqual(projectWithApp.app);
+        expect(project).toHaveProperty('id');
+        expect(project.id).toMatch(uuidv4Regex);
+        expect(project).toHaveProperty('name');
+        expect(project.name).toEqual(projectTwo.name);
+        expect(project).toHaveProperty('description');
+        expect(project.description).toEqual(projectTwo.description);
+        expect(project).toHaveProperty('stack');
+        expect(project.stack).toEqual(projectTwo.stack);
+        expect(project).toHaveProperty('sourceCode');
+        expect(project.sourceCode).toEqual(projectTwo.sourceCode);
+        expect(project).toHaveProperty('livePreview');
+        expect(project.livePreview).toEqual(projectTwo.livePreview);
     });
 
     it('should return 500 and not create when project name is found in database', async () => {
-        await Project.create(projectWithApp);
+        await Project.create(projectOne);
 
         const response = await supertest(app)
             .post('/v1/projects/create')
-            .send(projectWithApp)
+            .send(projectOne)
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
         expect(response.status).toEqual(500);
@@ -82,8 +87,6 @@ describe('CreateProjectController', () => {
         expect(response.body.error).toHaveProperty('statusCode');
         expect(response.body.error.statusCode).toEqual(500);
         expect(response.body.error).toHaveProperty('message');
-        expect(response.body.error.message).toEqual(
-            `Project ${projectWithApp.name} already exists.`
-        );
+        expect(response.body.error.message).toEqual(`Project ${projectOne.name} already exists.`);
     });
 });

--- a/src/tests/controllers/DeleteProjectController.int.test.ts
+++ b/src/tests/controllers/DeleteProjectController.int.test.ts
@@ -5,7 +5,8 @@ import supertest from 'supertest';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { app } from '../../app';
-import { projectWithApp } from '../mocks/Projects';
+import { projectOne } from '../mocks/Projects';
+import { ProjectModel } from '../../schemas/ProjectSchema';
 
 describe('DeleteProjectController', () => {
     let mongoServer: MongoMemoryServer;
@@ -25,9 +26,11 @@ describe('DeleteProjectController', () => {
     it('should delete the project with the given id', async () => {
         const createResponse = await supertest(app)
             .post('/v1/projects/create')
-            .send(projectWithApp)
+            .send(projectOne)
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
-        const { id } = createResponse.body.project;
+
+        const { project }: { project: ProjectModel } = createResponse.body;
+        const { id } = project;
 
         const response = await supertest(app)
             .delete(`/v1/projects/delete/${id}`)

--- a/src/tests/controllers/GetProjectsController.int.test.ts
+++ b/src/tests/controllers/GetProjectsController.int.test.ts
@@ -4,9 +4,9 @@ dotenv.config();
 import supertest from 'supertest';
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { projectWithApp } from '../mocks/Projects';
+import { projectOne } from '../mocks/Projects';
 import { app } from '../../app';
-import { Project, IProject } from '../../schemas/ProjectSchema';
+import { Project, ProjectModel } from '../../schemas/ProjectSchema';
 import { GetProjectsService } from '../../services';
 import { uuidv4Regex } from '../../utils';
 
@@ -26,7 +26,7 @@ describe('GetProjectsController', () => {
     });
 
     it('should return 200 and a list of projects', async () => {
-        await Project.create(projectWithApp);
+        await Project.create(projectOne);
 
         const response = await supertest(app).get('/v1/projects');
 
@@ -34,20 +34,20 @@ describe('GetProjectsController', () => {
         expect(response.body).toHaveProperty('projects');
         expect(response.body.projects).toHaveLength(1);
 
-        const project: IProject = response.body.projects[0];
+        const project: ProjectModel = response.body.projects[0];
 
         expect(project).toHaveProperty('id');
         expect(project).toHaveProperty('name');
         expect(project).toHaveProperty('description');
-        expect(project).toHaveProperty('github');
-        expect(project).toHaveProperty('logo');
-        expect(project).toHaveProperty('app');
+        expect(project).toHaveProperty('stack');
+        expect(project).toHaveProperty('sourceCode');
+        expect(project).toHaveProperty('livePreview');
         expect(project.id).toMatch(uuidv4Regex);
-        expect(project.name).toEqual(projectWithApp.name);
-        expect(project.description).toEqual(projectWithApp.description);
-        expect(project.github).toEqual(projectWithApp.github);
-        expect(project.logo).toEqual(projectWithApp.logo);
-        expect(project.app).toEqual(projectWithApp.app);
+        expect(project.name).toEqual(projectOne.name);
+        expect(project.description).toEqual(projectOne.description);
+        expect(project.stack).toEqual(projectOne.stack);
+        expect(project.sourceCode).toEqual(projectOne.sourceCode);
+        expect(project.livePreview).toEqual(projectOne.livePreview);
     });
 
     it('should return 200 and an empty list of projects', async () => {

--- a/src/tests/middlewares/CreateProjectHandler.int.test.ts
+++ b/src/tests/middlewares/CreateProjectHandler.int.test.ts
@@ -26,8 +26,9 @@ describe('ProjectAuthentication', () => {
             .post('/v1/projects/create')
             .send({
                 description: 'description',
-                github: 'github',
-                logo: 'logo'
+                stack: ['stack'],
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -47,8 +48,9 @@ describe('ProjectAuthentication', () => {
             .send({
                 name: 1,
                 description: 'description',
-                github: 'github',
-                logo: 'logo'
+                stack: ['stack'],
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -67,8 +69,9 @@ describe('ProjectAuthentication', () => {
             .post('/v1/projects/create')
             .send({
                 name: 'name',
-                github: 'github',
-                logo: 'logo'
+                stack: ['stack'],
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -88,8 +91,9 @@ describe('ProjectAuthentication', () => {
             .send({
                 name: 'name',
                 description: 1,
-                github: 'github',
-                logo: 'logo'
+                stack: ['stack'],
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -103,13 +107,14 @@ describe('ProjectAuthentication', () => {
         expect(response.body.error.statusCode).toEqual(400);
     });
 
-    it('should return an error because there is no github field', async () => {
+    it('should return an error because there is no stack field', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
             .send({
                 name: 'name',
                 description: 'description',
-                logo: 'logo'
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -118,19 +123,20 @@ describe('ProjectAuthentication', () => {
         expect(response.body.error).toHaveProperty('name');
         expect(response.body.error.name).toEqual('ApiError');
         expect(response.body.error).toHaveProperty('message');
-        expect(response.body.error.message).toEqual('Project Github link is required.');
+        expect(response.body.error.message).toEqual('Project stack is required.');
         expect(response.body.error).toHaveProperty('statusCode');
         expect(response.body.error.statusCode).toEqual(400);
     });
 
-    it('should return an error because github field is not a string', async () => {
+    it('should return an error because stack field is not a string array', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
             .send({
                 name: 'name',
                 description: 'description',
-                github: 1,
-                logo: 'logo'
+                stack: ['1', 2],
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -139,18 +145,19 @@ describe('ProjectAuthentication', () => {
         expect(response.body.error).toHaveProperty('name');
         expect(response.body.error.name).toEqual('ApiError');
         expect(response.body.error).toHaveProperty('message');
-        expect(response.body.error.message).toEqual('Project Github link must be a string.');
+        expect(response.body.error.message).toEqual('Project stack must be a string array.');
         expect(response.body.error).toHaveProperty('statusCode');
         expect(response.body.error.statusCode).toEqual(400);
     });
 
-    it('should return an error because there is no logo field', async () => {
+    it('should return an error because there is no sourceCode field', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
             .send({
                 name: 'name',
                 description: 'description',
-                github: 'github'
+                stack: ['stack'],
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -159,19 +166,20 @@ describe('ProjectAuthentication', () => {
         expect(response.body.error).toHaveProperty('name');
         expect(response.body.error.name).toEqual('ApiError');
         expect(response.body.error).toHaveProperty('message');
-        expect(response.body.error.message).toEqual('Project logo is required.');
+        expect(response.body.error.message).toEqual('Project sourceCode is required.');
         expect(response.body.error).toHaveProperty('statusCode');
         expect(response.body.error.statusCode).toEqual(400);
     });
 
-    it('should return an error because logo field is not a string', async () => {
+    it('should return an error because sourceCode field is not a string', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
             .send({
                 name: 'name',
                 description: 'description',
-                github: 'github',
-                logo: 1
+                stack: ['stack'],
+                sourceCode: 1,
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -180,20 +188,19 @@ describe('ProjectAuthentication', () => {
         expect(response.body.error).toHaveProperty('name');
         expect(response.body.error.name).toEqual('ApiError');
         expect(response.body.error).toHaveProperty('message');
-        expect(response.body.error.message).toEqual('Project logo must be a string.');
+        expect(response.body.error.message).toEqual('Project sourceCode must be a string.');
         expect(response.body.error).toHaveProperty('statusCode');
         expect(response.body.error.statusCode).toEqual(400);
     });
 
-    it('should return an error because app field was used and it is not a string', async () => {
+    it('should return an error because there is no livePreview field', async () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
             .send({
                 name: 'name',
                 description: 'description',
-                github: 'github',
-                logo: 'logo',
-                app: 1
+                stack: ['stack'],
+                sourceCode: 'sourceCode'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
@@ -202,7 +209,29 @@ describe('ProjectAuthentication', () => {
         expect(response.body.error).toHaveProperty('name');
         expect(response.body.error.name).toEqual('ApiError');
         expect(response.body.error).toHaveProperty('message');
-        expect(response.body.error.message).toEqual('Project app must be a string.');
+        expect(response.body.error.message).toEqual('Project livePreview is required.');
+        expect(response.body.error).toHaveProperty('statusCode');
+        expect(response.body.error.statusCode).toEqual(400);
+    });
+
+    it('should return an error because livePreview field is not a string', async () => {
+        const response = await supertest(app)
+            .post('/v1/projects/create')
+            .send({
+                name: 'name',
+                description: 'description',
+                stack: ['stack'],
+                sourceCode: 'sourceCode',
+                livePreview: 1
+            })
+            .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
+
+        expect(response.status).toEqual(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body.error).toHaveProperty('name');
+        expect(response.body.error.name).toEqual('ApiError');
+        expect(response.body.error).toHaveProperty('message');
+        expect(response.body.error.message).toEqual('Project livePreview must be a string.');
         expect(response.body.error).toHaveProperty('statusCode');
         expect(response.body.error.statusCode).toEqual(400);
     });

--- a/src/tests/middlewares/DeleteProjectHandler.int.test.ts
+++ b/src/tests/middlewares/DeleteProjectHandler.int.test.ts
@@ -5,6 +5,7 @@ import { MongoMemoryServer } from 'mongodb-memory-server';
 import supertest from 'supertest';
 import mongoose from 'mongoose';
 import { app } from '../../app';
+import { ProjectModel } from '../../schemas/ProjectSchema';
 
 describe('DeleteProjectHandler', () => {
     let mongoServer: MongoMemoryServer;
@@ -21,19 +22,23 @@ describe('DeleteProjectHandler', () => {
         await mongoServer.stop();
     });
 
-    it('should return delete the created project', async () => {
+    it('should delete the created project', async () => {
         const createResponse = await supertest(app)
             .post('/v1/projects/create')
             .send({
-                name: 'test',
-                description: 'test',
-                github: 'test',
-                logo: 'test'
+                name: 'name',
+                description: 'description',
+                stack: ['stack'],
+                sourceCode: 'sourceCode',
+                livePreview: 'livePreview'
             })
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
+        const { project }: { project: ProjectModel } = createResponse.body;
+        const createdProjectId = project.id;
+
         const response = await supertest(app)
-            .delete(`/v1/projects/delete/${createResponse.body.project.id}`)
+            .delete(`/v1/projects/delete/${createdProjectId}`)
             .set('Authorization', `Bearer ${process.env.AUTH_TOKEN}`);
 
         expect(response.status).toEqual(204);

--- a/src/tests/middlewares/ProjectAuthentication.int.test.ts
+++ b/src/tests/middlewares/ProjectAuthentication.int.test.ts
@@ -5,7 +5,7 @@ import supertest from 'supertest';
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import { app } from '../../app';
-import { projectWithApp, projectWithoutApp } from '../mocks/Projects';
+import { projectOne, projectTwo } from '../mocks/Projects';
 
 describe('ProjectAuthentication', () => {
     let mongoServer: MongoMemoryServer;
@@ -23,7 +23,7 @@ describe('ProjectAuthentication', () => {
     });
 
     it('should return an error telling to pass the authorization token in the headers', async () => {
-        const response = await supertest(app).post('/v1/projects/create').send(projectWithApp);
+        const response = await supertest(app).post('/v1/projects/create').send(projectOne);
 
         expect(response.status).toEqual(403);
         expect(response.body).toHaveProperty('error');
@@ -39,7 +39,7 @@ describe('ProjectAuthentication', () => {
         const response = await supertest(app)
             .post('/v1/projects/create')
             .set('authorization', 'Bearer faketoken')
-            .send(projectWithoutApp);
+            .send(projectTwo);
 
         expect(response.status).toEqual(401);
         expect(response.body).toHaveProperty('error');

--- a/src/tests/mocks/Projects.ts
+++ b/src/tests/mocks/Projects.ts
@@ -1,16 +1,17 @@
-import { IProject } from '../../schemas/ProjectSchema';
+import { RequestProjectBody } from '../../schemas/ProjectSchema';
 
-export const projectWithApp: IProject = {
+export const projectOne: RequestProjectBody = {
     name: 'Test Project',
     description: 'Test Project Description',
-    app: 'Test App',
-    github: 'Test Github',
-    logo: 'Test Logo'
+    stack: ['react', 'typescript'],
+    sourceCode: 'Source Test Project',
+    livePreview: 'Live Test Project'
 };
 
-export const projectWithoutApp: IProject = {
+export const projectTwo: RequestProjectBody = {
     name: 'Test Project 2',
     description: 'Test Project Description 2',
-    github: 'Test Github 2',
-    logo: 'Test Logo 2'
+    stack: ['angular', 'mongodb'],
+    sourceCode: 'Source Test Project 2',
+    livePreview: 'Live Test Project 2'
 };

--- a/src/tests/services/CreateProjectService.unit.test.ts
+++ b/src/tests/services/CreateProjectService.unit.test.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { IProject } from '../../schemas/ProjectSchema';
-import { projectWithApp } from '../mocks/Projects';
+import { ProjectModel } from '../../schemas/ProjectSchema';
+import { projectOne } from '../mocks/Projects';
 import { CreateProjectService } from '../../services';
 import { MongooseError } from '../../errors';
 import { uuidv4Regex } from '../../utils';
@@ -23,22 +23,22 @@ describe('CreateProjectService', () => {
 
     it('should create a project', async () => {
         const service = new CreateProjectService();
-        const result = (await service.execute(projectWithApp)) as IProject;
+        const result = (await service.execute(projectOne)) as ProjectModel;
 
-        expect(result.name).toEqual(projectWithApp.name);
-        expect(result.description).toEqual(projectWithApp.description);
-        expect(result.github).toEqual(projectWithApp.github);
-        expect(result.logo).toEqual(projectWithApp.logo);
-        expect(result.app).toEqual(projectWithApp.app);
         expect(result.id).toMatch(uuidv4Regex);
+        expect(result.name).toEqual(projectOne.name);
+        expect(result.description).toEqual(projectOne.description);
+        expect(result.stack).toEqual(projectOne.stack);
+        expect(result.sourceCode).toEqual(projectOne.sourceCode);
+        expect(result.livePreview).toEqual(projectOne.livePreview);
     });
 
     it('should throw an error if the project is found in the database', async () => {
         const service = new CreateProjectService();
-        (await service.execute(projectWithApp)) as IProject;
+        (await service.execute(projectOne)) as ProjectModel;
 
-        await expect(service.execute(projectWithApp)).rejects.toThrow(
-            MongooseError.projectAlreadyExists(projectWithApp.name)
+        await expect(service.execute(projectOne)).rejects.toThrow(
+            MongooseError.projectAlreadyExists(projectOne.name)
         );
     });
 });

--- a/src/tests/services/DeleteProjectService.unit.test.ts
+++ b/src/tests/services/DeleteProjectService.unit.test.ts
@@ -1,9 +1,9 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
 import { MongooseError } from '../../errors';
-import { IProject, Project } from '../../schemas/ProjectSchema';
+import { ProjectModel, Project } from '../../schemas/ProjectSchema';
 import { DeleteProjectService } from '../../services';
-import { projectWithApp } from '../mocks/Projects';
+import { projectOne } from '../mocks/Projects';
 
 describe('DeleteProjectService', () => {
     let mongoServer: MongoMemoryServer;
@@ -21,10 +21,10 @@ describe('DeleteProjectService', () => {
     });
 
     it('should delete the project with the given id', async () => {
-        const result: IProject = await Project.create(projectWithApp);
+        const result: ProjectModel = await Project.create(projectOne);
 
         const delService = new DeleteProjectService();
-        const delResult = await delService.execute(result.id as string);
+        const delResult = await delService.execute(result.id);
 
         expect(delResult).toBeUndefined();
     });

--- a/src/tests/services/GetProjectsService.unit.test.ts
+++ b/src/tests/services/GetProjectsService.unit.test.ts
@@ -1,8 +1,9 @@
 import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
-import { IProject, Project } from '../../schemas/ProjectSchema';
-import { projectWithApp, projectWithoutApp } from '../mocks/Projects';
+import { ProjectModel, Project } from '../../schemas/ProjectSchema';
+import { projectOne, projectTwo } from '../mocks/Projects';
 import { GetProjectsService } from '../../services';
+import { uuidv4Regex } from '../../utils';
 
 describe('GetProjectsService', () => {
     let mongoServer: MongoMemoryServer;
@@ -20,27 +21,30 @@ describe('GetProjectsService', () => {
     });
 
     it('should return a list of projects', async () => {
-        const project: IProject = await Project.create(projectWithApp);
-        const project2: IProject = await Project.create(projectWithoutApp);
+        const project: ProjectModel = await Project.create(projectOne);
+        const project2: ProjectModel = await Project.create(projectTwo);
 
         const service = new GetProjectsService();
-        const result = (await service.execute()) as IProject[];
+        const [resultOne, resultTwo] = (await service.execute()) as ProjectModel[];
 
-        expect(result[0].name).toEqual(project.name);
-        expect(result[0].description).toEqual(project.description);
-        expect(result[0].github).toEqual(project.github);
-        expect(result[0].logo).toEqual(project.logo);
-        expect(result[0].app).toEqual(project.app);
+        expect(resultOne.id).toMatch(uuidv4Regex);
+        expect(resultOne.name).toEqual(project.name);
+        expect(resultOne.description).toEqual(project.description);
+        expect(resultOne.stack).toEqual(project.stack);
+        expect(resultOne.sourceCode).toEqual(project.sourceCode);
+        expect(resultOne.livePreview).toEqual(project.livePreview);
 
-        expect(result[1].name).toEqual(project2.name);
-        expect(result[1].description).toEqual(project2.description);
-        expect(result[1].github).toEqual(project2.github);
-        expect(result[1].logo).toEqual(project2.logo);
+        expect(resultTwo.id).toMatch(uuidv4Regex);
+        expect(resultTwo.name).toEqual(project2.name);
+        expect(resultTwo.description).toEqual(project2.description);
+        expect(resultTwo.stack).toEqual(project2.stack);
+        expect(resultTwo.sourceCode).toEqual(project2.sourceCode);
+        expect(resultTwo.livePreview).toEqual(project2.livePreview);
     });
 
     it('should return an empty list of projects', async () => {
         const service = new GetProjectsService();
-        const result = (await service.execute()) as IProject[];
+        const result = (await service.execute()) as ProjectModel[];
         expect(result).toEqual([]);
     });
 });


### PR DESCRIPTION
This pull request is due to my frontend expecting a specific project structure, while this api gives another project structure.

Expected structure:
```ts
interface Project {
    id: string;
    name: string;
    description: string;
    stack: string[];
    sourceCode: string;
    livePreview: string;
}
```

Current given structure:
```ts
interface Project {
    id: string;
    name: string;
    description: string;
    github: string[];
    logo: string;
    app?: string;
}
```


This is a big commit, but only affects projects-related functionalities.